### PR TITLE
Add systemd service file to use iota-pm as a daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ IPM will connect to IOTA endpoint and produce the status at localhost port 8888
 To view the dashboard, simply open a browser and point to http://127.0.0.1:8888
 
 ``` 
+
+### As a daemon using systemd
+Copy the file located in systemd/iota-pm.service to /etc/systemd/system/iota-pm.service, modifying the parameters to match your setup.
+Run `systemctl daemon-reload` for reloading your configuration. From here on you can use normal start/stop/status commands to manage iota-pm as a daemon.
+
 ## Persistent Tag
 
 Any custom tag assigned to a peer will be saved inside user's home directory in file iota-pm.conf

--- a/systemd/iota-pm.service
+++ b/systemd/iota-pm.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=IOTA Peer Manager
+After=network.target
+
+[Service]
+User=iota
+Group=iota
+Type=simple
+ExecStart=/usr/bin/iota-pm -i http://127.0.0.1:14700 -p 0.0.0.0:8888
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I've wrote this systemd service file for my own use, and thought it can be useful for others. 
The hardcoded IPs could be easily exported to a file in /etc/default/iota-pm and source it from there, haven't done it because that precise location changes from distro to distro using systemd.
Also notice the use of iota user as best practice.