### PR TITLE
Temporarily use fixed version of iota.lib.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.15.3",
     "express-basic-auth": "^1.1.1",
     "gentelella": "^1.3.0",
-    "iota.lib.js": "^0.3.0",
+    "iota.lib.js": "git+https://github.com/rajivshah3/iota.lib.js.git",
     "jsonfile": "^4.0.0",
     "minimist": "^1.2.0",
     "restler": "^3.4.0",


### PR DESCRIPTION
This is a temporary fix until https://github.com/iotaledger/iota.lib.js/pull/106 is merged
Fixes #21 , thanks to @jjmiranda for pointing this out