### PR TITLE
Update counter and graph labels

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -164,7 +164,7 @@ socket.on('peerInfo', function(info){
           labels: [],
           datasets: [
             {
-              label: 'All TX',
+              label: 'Rec TX',
               borderColor: '#333',
               backgroundColor: 'rgba(0,0,0,0)',
               data: []

--- a/public/component/peer.js
+++ b/public/component/peer.js
@@ -24,11 +24,11 @@ var Template =`
                 
                 <div class="list-group-alt no-radius">
             
-                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfAllTransactions}}</span>All Transactions  </div> 
-                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfRandomTransactionRequests}}</span> Random Transactions  </div> 
-                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfNewTransactions}}</span> New Transactions  </div> 
-                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfInvalidTransactions}}</span>Invalid Transactions  </div> 
-                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfSentTransactions}}</span>Sent Transactions </div> 
+                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfSentTransactions}}</span>Sent Transactions</div>
+                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfAllTransactions}}</span>Received Transactions</div>
+                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfNewTransactions}}</span>Received New Transactions</div>
+                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfRandomTransactionRequests}}</span>Received Random Transaction Requests</div>
+                <div class="list-group-item" href="#"> <span class="badge bg-success">{{state.numberOfInvalidTransactions}}</span>Received Invalid Transactions</div>
                 </div>
                 </section>
         
@@ -66,7 +66,7 @@ var peer = Vue.component('peer', {
               labels: [],
               datasets: [
                 {
-                  label: 'All TX',
+                  label: 'Rec TX',
               
                   data: []
                 },


### PR DESCRIPTION
I found the existing counter labels to be a bit confusing at best (the API documentation on them is even worse), so I very quickly reviewed the iri code and hopefully came up with some better (and more accurate) labels.  I reordered them (in a compromise of importance and relation to each other).  I also changed a single graph label to match, but I did not reorder the graph labels because I did not want to change the actual graph display at this point.  This is what changed:
```
All Transactions -> Received Transactions
Random Transactions -> Received Random Transaction Requests
New Transactions ->  Received New Transactions
Invalid Transactions -> Received Invalid Transactions
Sent Transactions ->  Sent Transactions
```
Here is a preview:

![image](https://user-images.githubusercontent.com/11914193/33586213-42e9dfbe-d936-11e7-97a7-20217f5aba8f.png)
