### PR TITLE
Remove whitespace from new peer address

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -93,7 +93,8 @@ var systemTemplate = {
       // `this` inside methods points to the Vue instance
       //alert('Adding Peer ' + this.address + '!')
       // `event` is the native DOM event
-      socket.emit('addPeer', { address: this.address });
+      var normalizedAddress = this.address.replace(/\s/g, "");
+      socket.emit('addPeer', { address: normalizedAddress });
     },
     showNeighbors: function (event){
         var n = "";


### PR DESCRIPTION
# Problem
Adding a node with leading/trailing whitespace(s) leads to `You have provided an invalid URI for your Neighbor: udp://1.2.3.4:15600`

# Solution
Remove whitespaces on submit as done in this pr.